### PR TITLE
feat: bump SLE to 15.5

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 
 RUN zypper -n rm container-suseconnect && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*


### PR DESCRIPTION
**Problem:**
SLE 15 SP4 general ends on 31 Dec 2023.

**Solution:**
Bump SLE BCI images to to 15.5.

**Related Issue:**
https://github.com/harvester/harvester/issues/4757

**Test plan:**
Test basic operation can work.
