### PR TITLE
add ci for arm builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,76 +7,117 @@ platform:
   arch: amd64
 
 steps:
-- name: build
-  image: rancher/dapper:v0.6.0
-  commands:
-  - dapper ci
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
+  - name: build
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper ci
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
 
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    checksum_file: CHECKSUMsum-amd64.txt
-    checksum_flatten: true
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
+  - name: docker-publish-master
+    image: plugins/docker
+    settings:
+      build_args:
+        - ARCH=amd64
+        - VERSION=${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:8}-head
+      dockerfile: package/Dockerfile
+      password:
+        from_secret: docker_password
+      repo: "rancher/harvester-node-manager"
+      tag: ${DRONE_BRANCH}-head
+      username:
+        from_secret: docker_username
+    when:
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release/v*
+      event:
+        - push
 
-- name: docker-publish-master
-  image: plugins/docker
-  settings:
-    build_args:
-      - ARCH=amd64
-      - VERSION=${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:8}-head
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/harvester-node-manager"
-    tag: ${DRONE_BRANCH}-head
-    username:
-      from_secret: docker_username
-  when:
-    ref:
-      include:
-      - refs/heads/master
-      - refs/heads/release/v*
-    event:
-    - push
-
-- name: docker-publish
-  image: plugins/docker
-  settings:
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/harvester-node-manager"
-    tag: "${DRONE_TAG}"
-    username:
-      from_secret: docker_username
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
+  - name: docker-publish
+    image: plugins/docker
+    settings:
+      dockerfile: package/Dockerfile
+      password:
+        from_secret: docker_password
+      repo: "rancher/harvester-node-manager"
+      tag: "${DRONE_TAG}"
+      username:
+        from_secret: docker_username
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/head/master
+        - refs/tags/*
+      event:
+        - tag
 
 volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+---
+kind: pipeline
+name: arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+  - name: build
+    image: rancher/dapper:v0.6.0
+    commands:
+      - dapper ci
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+
+  - name: docker-publish-master
+    image: plugins/docker
+    settings:
+      build_args:
+        - ARCH=arm64
+        - VERSION=${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:8}-head
+      dockerfile: package/Dockerfile
+      password:
+        from_secret: docker_password
+      repo: "rancher/harvester-node-manager"
+      tag: ${DRONE_BRANCH}-head
+      username:
+        from_secret: docker_username
+    when:
+      ref:
+        include:
+          - refs/heads/master
+          - refs/heads/release/v*
+      event:
+        - push
+
+  - name: docker-publish
+    image: plugins/docker
+    settings:
+      dockerfile: package/Dockerfile
+      password:
+        from_secret: docker_password
+      repo: "rancher/harvester-node-manager"
+      tag: "${DRONE_TAG}"
+      username:
+        from_secret: docker_username
+    when:
+      instance:
+        - drone-publish.rancher.io
+      ref:
+        - refs/head/master
+        - refs/tags/*
+      event:
+        - tag
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -7,13 +7,10 @@ RUN zypper -n rm container-suseconnect && \
     zypper -n install git curl docker gzip tar wget awk
 
 ## install golangci
-RUN if [ "${ARCH}" == "amd64" ]; then \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.0; \
-    fi
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.0
 ## install controller-gen
-RUN if [ "${ARCH}" = "amd64" ]; then \
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2; \
-    fi
+RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2
+
 # install openapi-gen
 RUN  go install k8s.io/code-generator/cmd/openapi-gen@v0.23.7
 


### PR DESCRIPTION
Introduce drone ci pipeline for arm builds

also removed publishing of manager artifact binary to GH releases, as this is not really used directly by harvester.

related to: https://github.com/harvester/harvester/issues/371