### PR TITLE
Require CloudInit .spec.contents to be valid YAML

### DIFF
--- a/pkg/admitter/cloudinit_test.go
+++ b/pkg/admitter/cloudinit_test.go
@@ -56,6 +56,7 @@ func TestCreate(t *testing.T) {
 		{"filename collision", v1beta1.CloudInitSpec{Filename: "99_ssh.yaml"}, errFilenameTaken},
 		{"conflicts with protected file", v1beta1.CloudInitSpec{Filename: "helloworld.yaml"}, errProtectedFilename},
 		{"not yaml or yml file ext", v1beta1.CloudInitSpec{Filename: "a"}, errMissingExt},
+		{"not yaml contents", v1beta1.CloudInitSpec{Filename: "not.yaml", Contents: "hello, there"}, errNotYAML},
 	}
 
 	for _, tt := range tests {
@@ -96,6 +97,7 @@ func TestUpdate(t *testing.T) {
 		{"filename collision", v1beta1.CloudInitSpec{Filename: "99_ssh.yaml"}, errFilenameTaken},
 		{"conflicts with protected file", v1beta1.CloudInitSpec{Filename: "helloworld.yaml"}, errProtectedFilename},
 		{"not yaml or yml file ext", v1beta1.CloudInitSpec{Filename: "a"}, errMissingExt},
+		{"not yaml contents", v1beta1.CloudInitSpec{Filename: "not.yaml", Contents: "hello, there"}, errNotYAML},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The Elemental cloud-init executor will fail in disastrous ways instead of just discarding the document if the document's contents are not YAML. However, it does ignore instructions that it doesn't understand if the document is valid YAML.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Require that the CloudInit resource's .spec.contents are valid YAML.

Ideally we could use the yip package to parse and perform semantic analysis on the document as a richer form of validation here, but that package does not expose a way of reading those diagnostics. In client code, it only logs what the errors are (in fact, the function signature doesn't return an error.)

Some future work upstream in that package could be beneficial here to create an API such that the yip package can return errors to its caller instead of simply logging them.

**Related Issue:** https://github.com/harvester/harvester/issues/5119

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Deploy a build of the harvester-node-manager-webhook image from this PR to the Harvester cluster, then use this file to `kubectl create -f` and reboot, then expect:

1. The node comes back up
2. The node is Ready on the dashboard
3. The management URL is Ready on the dashboard
4. You can SSH in to the node
5. You can log in at the node's console
6. The last entry in the list below, `consolelogoverwrite` is rejected by the webhook for not being valid YAML

```
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: ssh-access
spec:
  matchSelector: {}
  filename: 99_ssh.yaml
  contents: |
    stages:
      network:
        - authorized_keys:
            rancher:
              - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBzZT+yXkr28BJzki4WdisefgyR1hKMXWlJCd9KfajEm michael.russell@suse.com
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: grubcustom
spec:
  matchSelector: {}
  filename: grubcustom
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: 99settings
spec:
  matchSelector: {}
  filename: 99_settings.yaml
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: 90custom
spec:
  matchSelector: {}
  filename: 90_custom.yaml
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: elemental.config
spec:
  matchSelector: {}
  filename: elemental.config
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: grubenv
spec:
  matchSelector: {}
  filename: grubenv
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: harvesterconfig
spec:
  matchSelector: {}
  filename: harvester.config
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: install
spec:
  matchSelector: {}
  filename: install
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: consolelogoverwrite
spec:
  matchSelector: {}
  filename: install/console.log
  contents: |
    hello  there
```