### PR TITLE
Fix CloudInit resource Condition LastTransitionTime fields

### DIFF
--- a/pkg/controller/cloudinit/controller.go
+++ b/pkg/controller/cloudinit/controller.go
@@ -36,6 +36,11 @@ const (
 	eventReasonReconcile = "CloudInitFileModified"
 	eventActionRemove    = "RemoveFile"
 	eventReasonRemove    = "CloudInitNotApplicable"
+
+	// This is mainly used for detecting a "zero value" for timestamps
+	// in a call to stat, where 0 means it has been 0 seconds since the
+	// unix epoch.
+	epoch int64 = 0
 )
 
 type controller struct {
@@ -176,6 +181,14 @@ func (c *controller) updateStatus(node *corev1.Node, cloudInitObj *cloudinitv1.C
 	}
 
 	now := time.Now()
+
+	if createdAt.Unix() == epoch {
+		createdAt = now
+	}
+	if modifiedAt.Unix() == epoch {
+		modifiedAt = now
+	}
+
 	for i := range conds {
 		cond := &conds[i]
 		prev := oldConds[cond.Type]


### PR DESCRIPTION
**Problem:**

When the stat call fails due to the file having been removed, the CloudInit controller leaves a zero-value/zero seconds since the epoch timestamp for the transition time, instead of the time the controller first detected the issue.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

 Two patches to do so:
 
 The first patch factors out common logic for retaining the LastTransitionTime for all Conditions, not just the Applicable condition.
 
 The second patch sets the createdAt and modifiedAt times to the current time if they are set to the zero-seconds-from the epoch time. If they are set to the epoch, then that means an error occurred during the Stat call for a normal and expected reason (file does not exist) or an unexpected reason (permission denied while calculating checksum).
 
 We set it to the current time in this instance since that is the time we first detected the error.

**Related Issue:** https://github.com/harvester/harvester/issues/5245

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Apply a CloudInit resource:

```
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: ssh-access
spec:
  matchSelector: {}
  filename: 99_ssh.yaml
  contents: |
    stages:
      network:
        - authorized_keys:
            rancher:
              - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPCUNsQEnKj0nl1GS07Qr5RDCCbCim4wu06hCzQZDmTk ckuehl@suselaptop
```

2. Set `paused: true` in the CloudInit resource
3. Remove the file from the node `rm /oem/99_ssh.yaml`

**Expected behavior**

The last transition times should either be the time the controller removed the file or the time that it first noticed that it was removed.
