### PR TITLE
Update testing node-manager charts

### DIFF
--- a/charts/harvester-node-manager/.helmignore
+++ b/charts/harvester-node-manager/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/harvester-node-manager/Chart.yaml
+++ b/charts/harvester-node-manager/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.0.0-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.3.0
+appVersion: "v0.1.1"
 
 maintainers:
   - name: harvester

--- a/charts/harvester-node-manager/templates/crds/node.harvesterhci.io_nodeconfigs.yaml
+++ b/charts/harvester-node-manager/templates/crds/node.harvesterhci.io_nodeconfigs.yaml
@@ -36,6 +36,11 @@ spec:
             type: object
           spec:
             properties:
+              longhornConfig:
+                properties:
+                  enableV2DataEngine:
+                    type: boolean
+                type: object
               ntpConfigs:
                 properties:
                   ntpServers:

--- a/charts/harvester-node-manager/templates/daemonset.yaml
+++ b/charts/harvester-node-manager/templates/daemonset.yaml
@@ -37,9 +37,12 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
-            - mountPath: /sys/kernel/mm/ksm
-              name: ksm
+            - mountPath: /sys/kernel/mm
+              name: mm
               readOnly: false
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
             - mountPath: /host/proc
               name: proc
               readOnly: true
@@ -57,9 +60,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        - name: ksm
+        - name: mm
           hostPath:
-            path: /sys/kernel/mm/ksm
+            path: /sys/kernel/mm
+        - name: modules
+          hostPath:
+            path: /lib/modules
         - name: proc
           hostPath:
             path: /proc

--- a/charts/harvester-node-manager/values.yaml
+++ b/charts/harvester-node-manager/values.yaml
@@ -3,9 +3,9 @@
 # Declare variables to be passed into your templates.
 image:
   repository: rancher/harvester-node-manager
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "master-head"
 
 resources:
   limits:
@@ -28,4 +28,4 @@ webhook:
   image:
     repository: rancher/harvester-node-manager-webhook
     pullPolicy: Always
-    tag: "v0.3.0"
+    tag: "master-head"


### PR DESCRIPTION
This pr basically copy content in https://github.com/harvester/charts/tree/release/charts/harvester-node-manager to node-manager charts.

The chart in node-manager is intended for testing usage. Github actions will trigger the `deploy_nm.sh` to deploy the latest release of node-manager to the vagrant-rancher cluster [0] (now latest nm release chart is v0.3.3), then the node manager chart will be upgraded to the version in the node-manager repo [1]. 
Please not that it is necessary to sync the node-manager charts between this repo and https://github.com/harvester/charts/tree/master/charts/harvester-node-manager (master branch) to ensure that the CI pipeline tests the upgrade path correctly, from the latest release to the development version.

[0]: https://github.com/harvester/node-manager/blob/master/ci/deploy_nm.sh
[1]: https://github.com/harvester/node-manager/blob/master/ci/upgrade_nm.sh