### PR TITLE
Bump golang to v1.23

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.23
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/node-manager
 
-go 1.22.5
+go 1.23.4
 
 replace (
 	k8s.io/api => k8s.io/api v0.30.3


### PR DESCRIPTION
related to https://github.com/harvester/harvester/issues/7336, bump golang to v1.23