### PR TITLE
minor change to disable module unloading when v2 engine is disabled

### DIFF
--- a/pkg/controller/nodeconfig/config/longhorn.go
+++ b/pkg/controller/nodeconfig/config/longhorn.go
@@ -155,11 +155,6 @@ func DisableV2DataEngine() error {
 		return err
 	}
 
-	// ...then try to do the runtime deactivation
-	if err := modprobe(modulesToLoad, false); err != nil {
-		return fmt.Errorf("unable to unload kernel modules %v: %v", modulesToLoad, err)
-	}
-
 	if origHugepages == 0 {
 		// We already don't have any hugepages, and don't want to unnecessarily
 		// restart the kubelet, so no further action required


### PR DESCRIPTION
This is needed to ensure other components such as pcidevices controller and 3rd party csi can continue to use kernel modules such as vfio-pci and nvme-tcp

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
When longhorn-v2 data engine is disabled, the node-manager will continue to reconcile the node and unload the following kernel modules

```
"vfio_pci", "uio_pci_generic", "nvme_tcp"
```

These modules may be needed by other 3rd party components such as pcidevices controller and 3rd party CSI

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Skip module unloading via the node-manager. These modules will be unloaded during next reboot if they are not needed.

If an additional component needs these modules then they will be loaded by these components.

The change ensures that node-manager does not interfere with operation of 3rd party components.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8385
#### Test plan:
<!-- Describe the test plan by steps. -->

* Install Harvester build containing the fix
* Enable pcidevice-controller addon
* Log in to the node
* Run `lsmod | grep vfio` It should show the these modules.
```
vfio_iommu_type1       40960  0
vfio_pci               16384  0
vfio_pci_core          69632  1 vfio_pci
vfio                   32768  2 vfio_pci_core,vfio_iommu_type1
vfio_virqfd            16384  1 vfio_pci_core
irqbypass              16384  2 vfio_pci_core,kvm
```

* After few hours (maybe fix/six hours), run lsmod | grep vfio again. It should only show the original modules still loaded.
```
vfio_iommu_type1       40960  0
vfio_pci               16384  0
vfio_pci_core          69632  1 vfio_pci
vfio                   32768  2 vfio_pci_core,vfio_iommu_type1
vfio_virqfd            16384  1 vfio_pci_core
irqbypass              16384  2 vfio_pci_core,kvm
```


#### Additional documentation or context
