### PR TITLE
ci: set up Go from go.mod in template build

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           ref: ${{ inputs.refs }}
 
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
       - name: "Run validations"
         run: |
           make validate


### PR DESCRIPTION
Ensure CI uses the Go version declared by the checked-out branch instead of relying on the self-hosted runner’s default Go installation.