### PR TITLE
Revert "chore(ci): update rancher-eio/read-vault-secrets digest to 0d…

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,7 +20,7 @@ jobs:
     # The FOSSA token is shared between all repos in Harvester's GH org. It can
     # be used directly and there is no need to request specific access to EIO.
     - name: Read FOSSA token
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@d266f55186f80a893839f6e15662e67388e443e6 # v3
       with:
         secrets: |
           secret/data/github/org/harvester/fossa/credentials token | FOSSA_API_KEY_PUSH_ONLY

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -103,7 +103,7 @@ jobs:
         run: make package-webhook
 
       - name: Read Secrets
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        uses: rancher-eio/read-vault-secrets@d266f55186f80a893839f6e15662e67388e443e6 # v3
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;


### PR DESCRIPTION
fossa workflow failed after merging https://github.com/harvester/node-manager/commit/d02458259e4fcc76e2dc2c426e5f6e4a8a1e6d13

The root cause is:

Old d266f55 uses the pinned dependency: hashicorp/vault-action@4c06c5c
New 0da8515 uses: hashicorp/vault-action@v3
Although hashicorp/vault-action@* is allowlisted, the enterprise separately requires actions to use full commit SHAs. GitHub applies that requirement to nested actions inside composite actions too. [GitHub documents this SHA-pinning policy](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization).