### PR TITLE
Fix nightly build didn't checkout to correct reference

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -92,8 +92,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Checkout code
+      - name: Checkout code without refs
+        if: ${{ inputs.refs == '' }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Checkout code with refs
+        if: ${{ inputs.refs != '' }}
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.refs }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3


### PR DESCRIPTION
thanks @bk201  for reporting this issue, currently nightly build doesn't checkout to correct reference for v1.7/v1.8 branch, it all checkout to master head which is incorrect.